### PR TITLE
Fixed prototype pollution bug on grunt-util-property

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,9 @@ module.exports = function(grunt) {
 	var _ = grunt.util._;
 
 	return function (key, value) {
+		if (key.includes('__proto__') || key.includes('constructor') || key.includes('prototype')) {
+			return node;
+		}
 		var node = this;
 		var parts = grunt.util.kindOf(key) === "array"
 			? key


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-grunt-util-property

### ⚙️ Description *

grunt-util-property is a Grunt util for getting and setting properties, this package are vulnerable to Prototype Pollution.
The function call could be tricked into adding or modifying properties of Object.prototype using a proto payload.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `key` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `123`.
```javascript
var grunt = require("grunt");
var a = require("grunt-util-property");
var b = a(grunt);
b.call({}, '__proto__.toString', 123);
console.log({}.toString);
```

![image](https://user-images.githubusercontent.com/16708391/92397922-3c01a680-f145-11ea-9797-536acb369296.png)


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns an error since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/92397823-14aad980-f145-11ea-9b46-ace8c9612f11.png)


### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `key` and no breaking changes are introduced. :)
